### PR TITLE
Allow browsing monthly summaries

### DIFF
--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import '../models/transaction.dart' as models;
 
 // データベース操作を管理するクラス
@@ -19,7 +22,14 @@ class DatabaseHelper {
   factory DatabaseHelper() => _instance;
 
   // プライベートコンストラクタ：外部からの直接インスタンス化を防ぐ
-  DatabaseHelper._internal();
+  DatabaseHelper._internal() {
+    // デスクトップ環境やテスト環境ではsqflite_common_ffiを使用して初期化
+    if (!kIsWeb &&
+        (Platform.isLinux || Platform.isWindows || Platform.isMacOS)) {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+    }
+  }
 
   // データベースインスタンスを保存する変数
   // null許可型（?）：初期状態ではnull、初期化後にDatabaseインスタンスを格納

--- a/lib/screens/chart_screen.dart
+++ b/lib/screens/chart_screen.dart
@@ -44,7 +44,7 @@ class ChartScreen extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // 今月のサマリー
+                // 月のサマリー
                 _buildMonthlySummary(context, provider),
                 const SizedBox(height: 24),
 
@@ -75,7 +75,7 @@ class ChartScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              '今月のサマリー',
+              '${provider.selectedYear}年${provider.selectedMonth}月のサマリー',
               style: Theme.of(
                 context,
               ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
@@ -87,22 +87,22 @@ class ChartScreen extends StatelessWidget {
                 _buildSummaryItem(
                   context,
                   '収入',
-                  '¥${formatter.format(provider.thisMonthIncome)}',
+                  '¥${formatter.format(provider.monthlyIncome)}',
                   Colors.green,
                   Icons.trending_up,
                 ),
                 _buildSummaryItem(
                   context,
                   '支出',
-                  '¥${formatter.format(provider.thisMonthExpense)}',
+                  '¥${formatter.format(provider.monthlyExpense)}',
                   Colors.red,
                   Icons.trending_down,
                 ),
                 _buildSummaryItem(
                   context,
                   '残高',
-                  '¥${formatter.format(provider.thisMonthBalance)}',
-                  provider.thisMonthBalance >= 0 ? Colors.blue : Colors.orange,
+                  '¥${formatter.format(provider.monthlyBalance)}',
+                  provider.monthlyBalance >= 0 ? Colors.blue : Colors.orange,
                   Icons.account_balance_wallet,
                 ),
               ],

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -45,7 +45,10 @@ class HomeScreen extends StatelessWidget {
         builder: (context, provider, child) {
           return Column(
             children: [
-              // サマリーカード：今月の収支を表示
+              // 月切り替えセレクタ
+              _buildMonthSelector(context, provider),
+
+              // サマリーカード：選択中の月の収支を表示
               _buildSummaryCards(context, provider),
 
               // 取引履歴リスト：残りのスペースを使用
@@ -74,6 +77,40 @@ class HomeScreen extends StatelessWidget {
   }
 
   // =============================================================================
+  // 月切り替えウィジェット
+  // =============================================================================
+
+  Widget _buildMonthSelector(
+    BuildContext context,
+    TransactionProvider provider,
+  ) {
+    final label = '${provider.selectedYear}年${provider.selectedMonth}月';
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.chevron_left),
+            onPressed: () {
+              provider.previousMonth();
+            },
+          ),
+          Text(label, style: Theme.of(context).textTheme.titleMedium),
+          IconButton(
+            icon: const Icon(Icons.chevron_right),
+            onPressed: provider.isCurrentMonth
+                ? null
+                : () {
+                    provider.nextMonth();
+                  },
+          ),
+        ],
+      ),
+    );
+  }
+
+  // =============================================================================
   // サマリーカード作成メソッド
   // =============================================================================
 
@@ -94,7 +131,7 @@ class HomeScreen extends StatelessWidget {
             child: _buildSummaryCard(
               context,
               '収入',
-              '¥${formatter.format(provider.thisMonthIncome)}',
+              '¥${formatter.format(provider.monthlyIncome)}',
               Colors.green, // 収入は緑色
               Icons.arrow_upward, // 上向き矢印
             ),
@@ -104,7 +141,7 @@ class HomeScreen extends StatelessWidget {
             child: _buildSummaryCard(
               context,
               '支出',
-              '¥${formatter.format(provider.thisMonthExpense)}',
+              '¥${formatter.format(provider.monthlyExpense)}',
               Colors.red, // 支出は赤色
               Icons.arrow_downward, // 下向き矢印
             ),
@@ -114,9 +151,9 @@ class HomeScreen extends StatelessWidget {
             child: _buildSummaryCard(
               context,
               '残高',
-              '¥${formatter.format(provider.thisMonthBalance)}',
+              '¥${formatter.format(provider.monthlyBalance)}',
               // 三項演算子：残高がマイナスの場合はオレンジ、プラスは青
-              provider.thisMonthBalance >= 0 ? Colors.blue : Colors.orange,
+              provider.monthlyBalance >= 0 ? Colors.blue : Colors.orange,
               Icons.account_balance_wallet, // 財布アイコン
             ),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   provider: ^6.1.1
   sqflite: ^2.3.0
+  sqflite_common_ffi: ^2.3.0
   path: ^1.8.3
   shared_preferences: ^2.2.2
   fl_chart: ^0.64.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,10 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:kakeibo_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('ホーム画面のタイトルが表示される', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('家計簿アプリ'), findsOneWidget);
   });
 }
+


### PR DESCRIPTION
## Summary
- support selecting year/month in `TransactionProvider`
- add month navigation UI on home screen
- show selected month data in chart screen
- initialize sqflite_common_ffi for desktop/test environments to avoid uninitialized databaseFactory errors

## Testing
- `dart pub get` *(command not found: dart)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6899a7cc448c8331a12a2feff80a07f9